### PR TITLE
Change references to GitHub user nextgensparx to siphomateke

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
-Copyright (c) 2017 Sipho Mateke (github: nextgensparx)
+Copyright (c) 2017 Sipho Mateke (github: siphomateke)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This code base was informed by the research work carried out in the following pu
 
 ----
 
-**Acknowledgements:** originally forked from an earlier Bag of Visual Words only version at https://github.com/nextgensparx/PyBOW with the additional HOG and selective search code added to this newer version.
+**Acknowledgements:** originally forked from an earlier Bag of Visual Words only version at https://github.com/siphomateke/PyBOW with the additional HOG and selective search code added to this newer version.
 
 _[ but it appears some code portions may have broader origins elsewhere, such as from this tutorial - https://www.pyimagesearch.com/2015/03/23/sliding-windows-for-object-detection-with-python-and-opencv/ ]_
 

--- a/bow_detector.py
+++ b/bow_detector.py
@@ -6,7 +6,7 @@
 # This version: (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
 # License: MIT License
 
-# Origin ackowledgements: forked from https://github.com/nextgensparx/PyBOW
+# Origin ackowledgements: forked from https://github.com/siphomateke/PyBOW
 
 ################################################################################
 

--- a/bow_test.py
+++ b/bow_test.py
@@ -7,7 +7,7 @@
 # This version: (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
 # License: MIT License
 
-# Origin acknowledgements: forked from https://github.com/nextgensparx/PyBOW
+# Origin acknowledgements: forked from https://github.com/siphomateke/PyBOW
 
 ################################################################################
 

--- a/bow_train.py
+++ b/bow_train.py
@@ -7,7 +7,7 @@
 # This version: (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
 # License: MIT License
 
-# Origin acknowledgements: forked from https://github.com/nextgensparx/PyBOW
+# Origin acknowledgements: forked from https://github.com/siphomateke/PyBOW
 
 ################################################################################
 

--- a/hog_detector.py
+++ b/hog_detector.py
@@ -6,7 +6,7 @@
 # This version: (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
 # License: MIT License
 
-# Minor portions: based on fork from https://github.com/nextgensparx/PyBOW
+# Minor portions: based on fork from https://github.com/siphomateke/PyBOW
 
 ################################################################################
 

--- a/hog_test.py
+++ b/hog_test.py
@@ -7,7 +7,7 @@
 # This version: (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
 # License: MIT License
 
-# Minor portions: based on fork from https://github.com/nextgensparx/PyBOW
+# Minor portions: based on fork from https://github.com/siphomateke/PyBOW
 
 ################################################################################
 

--- a/hog_train.py
+++ b/hog_train.py
@@ -7,7 +7,7 @@
 # This version: (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
 # License: MIT License
 
-# Minor portions: based on fork from https://github.com/nextgensparx/PyBOW
+# Minor portions: based on fork from https://github.com/siphomateke/PyBOW
 
 ################################################################################
 

--- a/params.py
+++ b/params.py
@@ -5,7 +5,7 @@
 # This version: (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
 # License: MIT License
 
-# Origin acknowledgements: forked from https://github.com/nextgensparx/PyBOW
+# Origin acknowledgements: forked from https://github.com/siphomateke/PyBOW
 
 ################################################################################
 

--- a/sliding_window.py
+++ b/sliding_window.py
@@ -5,7 +5,7 @@
 # This version: (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
 # License: MIT License
 
-# Origin acknowledgements: forked from https://github.com/nextgensparx/PyBOW
+# Origin acknowledgements: forked from https://github.com/siphomateke/PyBOW
 
 ################################################################################
 

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,7 @@
 # This version: (c) 2018 Toby Breckon, Dept. Computer Science, Durham University, UK
 # License: MIT License
 
-# Origin acknowledgements: forked from https://github.com/nextgensparx/PyBOW
+# Origin acknowledgements: forked from https://github.com/siphomateke/PyBOW
 
 ################################################################################
 


### PR DESCRIPTION
I changed my username from nextgensparx to siphomateke. This pull request replaces all references to my old username with my new one.